### PR TITLE
Remove Jupyterlab git extension (for now)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ ENV DEBUG=false \
     REMOTE_HOST=none \
     GALAXY_URL=none
 
-RUN jupyter labextension install @jupyterlab/geojson-extension @jupyterlab/toc-extension @jupyterlab/katex-extension @jupyterlab/fasta-extension @jupyterlab/git
+RUN jupyter labextension install @jupyterlab/geojson-extension @jupyterlab/toc-extension @jupyterlab/katex-extension @jupyterlab/fasta-extension
 
 # @jupyterlab/google-drive  not yet supported
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN conda config --add channels conda-forge && \
     ansible-kernel \
     bioblend galaxy-ie-helpers \
     # Jupyter widgets
-    jupyterlab-git jupytext \
+    jupytext \
     cython patsy statsmodels cloudpickle dill r-xml && conda clean -yt && \
     pip install jupyterlab_hdf
 


### PR DESCRIPTION
The [official documentation](https://github.com/jupyterlab/jupyterlab-git) of jupyterlab/git claims that the Git extension for jupyterlab notebook works for jupyterlab > 3.0 but I have not been able to get it running. Just installing jupyterlab-git via pip or conda does not seem to work as suggested in the documentation. Therefore, to avoid the error (about version mismatch of git server and UI extensions) on the load of jupyterlab notebook in Galaxy, I propose to remove it for now. Once it is fixed, we will have it integrated back to jupyterlab notebook in Galaxy.

ping @bgruening 