### PR TITLE
Update ipython-profile.py

### DIFF
--- a/ipython-profile.py
+++ b/ipython-profile.py
@@ -1,3 +1,4 @@
+import os
 from galaxy_ie_helpers import get
 from galaxy_ie_helpers import put
 from galaxy_ie_helpers import get_galaxy_connection


### PR DESCRIPTION
Need to import `os` for the call to `os.environ` to allow `HISTORY_ID` to be declared, otherwise the startup process will terminate. `HISTORY_ID` will not be available automatically in the notebook environment and any higher numbered startup scripts will fail to execute.