### PR TITLE
GH actions added

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,30 @@
+name: PR
+
+on:
+  pull_request:
+    branches: [ "main", "master" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  initialise:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+          
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+   
+  build_only:
+    needs: initialise
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Build docker image
+        uses: docker/build-push-action@v4
+        with:
+          push: false
+          tags: user/app:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: release-CI
+
+on:
+  release:
+    types: [published]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  build_and_publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v3
+          
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+        
+      - name: Login to Quay IO
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: '$oauthtoken'
+          password: ${{ secrets.QUAY_OAUTH_TOKEN }}
+    
+      - name: Build docker image and push to quay.io
+        uses: docker/build-push-action@v4
+        with:
+          push: true
+          tags: quay.io/galaxy/docker-jupyter-notebook:${{ github.event.release.tag_name }}
+
+


### PR DESCRIPTION
@bgruening I added workflows for PR tests and auto-upload on release. More or less copy-paste from GPU-enabled version.

Does this also move to the same account on quay (quay.io/galaxy/docker-jupyter-notebook) rather than quay.io/bgruening/docker-jupyter-notebook?