### PR TITLE
content-Security-Policy error fixed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ RUN conda update -n base -c conda-forge conda && \
         jupyterlab-fasta \
         mamba \
         patsy \
+        pip \
         r-xml \
         rpy2 \
         statsmodels && \

--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -11,12 +11,12 @@ headers = {
     'X-Frame-Options': 'ALLOWALL',
     'Content-Security-Policy':
         "; ".join([
-            "default-src 'self' https: %(CORS_ORIGIN)s",
-            "img-src 'self' data: %(CORS_ORIGIN)s",
-            "connect-src 'self' %(WS_CORS_ORIGIN)s",
-            "style-src 'unsafe-inline' 'self' %(CORS_ORIGIN)s",
-            "script-src https: 'unsafe-inline' 'unsafe-eval' 'self' %(CORS_ORIGIN)s"
-        ]) % {'CORS_ORIGIN': CORS_ORIGIN, 'WS_CORS_ORIGIN': 'ws://%s' % CORS_ORIGIN_HOSTNAME}
+            f"default-src 'self' https: {CORS_ORIGIN}",
+            f"img-src 'self' data: {CORS_ORIGIN}",
+            f"connect-src 'self' ws://{CORS_ORIGIN_HOSTNAME}",
+            f"style-src 'unsafe-inline' 'self' {CORS_ORIGIN}",
+            f"script-src https: 'unsafe-inline' 'unsafe-eval' 'self' {CORS_ORIGIN}"
+        ])
 }
 
 # Configuration file for jupyter-notebook.

--- a/jupyter_notebook_config.py
+++ b/jupyter_notebook_config.py
@@ -9,13 +9,14 @@ if os.environ['CORS_ORIGIN'] != 'none':
 
 headers = {
     'X-Frame-Options': 'ALLOWALL',
-        'Content-Security-Policy': """
-            default-src 'self' %(CORS_ORIGIN)s; 
-            img-src 'self' %(CORS_ORIGIN)s;
-            connect-src 'self' %(WS_CORS_ORIGIN)s;
-            style-src 'unsafe-inline' 'self' %(CORS_ORIGIN)s;
-            script-src 'unsafe-inline' 'self' %(CORS_ORIGIN)s;
-        """ % {'CORS_ORIGIN': CORS_ORIGIN, 'WS_CORS_ORIGIN': 'ws://%s' % CORS_ORIGIN_HOSTNAME}
+    'Content-Security-Policy':
+        "; ".join([
+            "default-src 'self' https: %(CORS_ORIGIN)s",
+            "img-src 'self' data: %(CORS_ORIGIN)s",
+            "connect-src 'self' %(WS_CORS_ORIGIN)s",
+            "style-src 'unsafe-inline' 'self' %(CORS_ORIGIN)s",
+            "script-src https: 'unsafe-inline' 'unsafe-eval' 'self' %(CORS_ORIGIN)s"
+        ]) % {'CORS_ORIGIN': CORS_ORIGIN, 'WS_CORS_ORIGIN': 'ws://%s' % CORS_ORIGIN_HOSTNAME}
 }
 
 # Configuration file for jupyter-notebook.


### PR DESCRIPTION
* A content-Security-Policy was implemented, but was dysfunctional due to syntax error, leading to errors like these: https://github.com/tornadoweb/tornado/issues/3240. Re-implemented with as restrictive conditions as the functionality allows. Same problem as in:  https://github.com/usegalaxy-eu/gpu-jupyterlab-docker/pull/6
*  The docker build failed, added pip.