### PR TITLE
Content-Security-Policy syntax error

### DIFF
--- a/jupyter_lab_config.py
+++ b/jupyter_lab_config.py
@@ -9,13 +9,14 @@ if os.environ['CORS_ORIGIN'] != 'none':
 
 headers = {
     'X-Frame-Options': 'ALLOWALL',
-        'Content-Security-Policy': """
-            default-src 'self' %(CORS_ORIGIN)s; 
-            img-src 'self' %(CORS_ORIGIN)s;
-            connect-src 'self' %(WS_CORS_ORIGIN)s;
-            style-src 'unsafe-inline' 'self' %(CORS_ORIGIN)s;
-            script-src 'unsafe-inline' 'self' %(CORS_ORIGIN)s;
-        """ % {'CORS_ORIGIN': CORS_ORIGIN, 'WS_CORS_ORIGIN': 'ws://%s' % CORS_ORIGIN_HOSTNAME}
+    'Content-Security-Policy':
+        "; ".join([
+            f"default-src 'self' https: {CORS_ORIGIN}",
+            f"img-src 'self' data: {CORS_ORIGIN}",
+            f"connect-src 'self' ws://{CORS_ORIGIN_HOSTNAME}",
+            f"style-src 'unsafe-inline' 'self' {CORS_ORIGIN}",
+            f"script-src https: 'unsafe-inline' 'unsafe-eval' 'self' {CORS_ORIGIN}"
+        ])
 }
 
 # Configuration file for lab.


### PR DESCRIPTION
Turns out this code block appears at 2 points, and both are copied into the container via Dockerfile. This should likewise error out. 