### PR TITLE
Enable Jupyter kernels for batch execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN conda config --add channels bioconda && \
     conda --version
 
 # Install python and jupyter packages
-RUN conda install --yes \
+RUN conda install --yes \ 
     bioblend galaxy-ie-helpers \
     biopython \
     cloudpickle \

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,9 @@ RUN conda create -n octave-kernel python=3.8 --yes && \
 RUN conda create -n ansible-kernel --yes ansible-kernel jupyter_client bioblend galaxy-ie-helpers && \
     conda run -n ansible-kernel python -m ansible_kernel.install
 
+RUN conda clean --all -y && \
+    chmod a+w+r /opt/conda/ -R
+
 ADD ./startup.sh /startup.sh
 #ADD ./monitor_traffic.sh /monitor_traffic.sh
 ADD ./get_notebook.py /get_notebook.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,30 +35,45 @@ RUN conda install --yes \
     ##
     ## Now create separate environments, that are managed by nb_conda_kernels
     ##
-    conda create -n ansible-kernel --yes ansible-kernel bioblend galaxy-ie-helpers && \
-    conda create -n bash-kernel --yes bash_kernel bioblend galaxy-ie-helpers && \
-    conda create -n octave-kernel --yes octave_kernel bioblend galaxy-ie-helpers  && \
-    conda create -n python-kernel-3.12 --yes python=3.12 ipykernel bioblend galaxy-ie-helpers  && \
-    conda create -n rlang-kernel --yes r-base r-irkernel r-xml rpy2 bioblend galaxy-ie-helpers \
-        'r-caret' \
-        'r-crayon' \
-        'r-devtools' \
-        'r-e1071' \
-        'r-forecast' \
-        'r-hexbin' \
-        'r-htmltools' \
-        'r-htmlwidgets' \
-        'r-irkernel' \
-        'r-nycflights13' \
-        'r-randomforest' \
-        'r-rcurl' \
-        'r-rmarkdown' \
-        'r-rodbc' \
-        'r-rsqlite' \
-        'r-shiny' \
-        'r-tidymodels' \
-        'r-tidyverse' \
-        'unixodbc' && \
+    conda create -n ansible-kernel --yes && \
+    conda run -n ansible-kernel pip install ipykernel bioblend galaxy-ie-helpers && \
+    conda run -n ansible-kernel python -m ipykernel install --user --name ansible-kernel --display-name "Ansible Kernel" && \
+
+    conda create -n bash-kernel --yes && \
+    conda run -n bash-kernel pip install bash_kernel bioblend galaxy-ie-helpers && \
+    conda run -n bash-kernel python -m ipykernel install --user --name bash-kernel --display-name "bash" && \
+
+    conda create -n octave-kernel --yes && \
+    conda run -n octave-kernel pip install octave-kernel bioblend galaxy-ie-helpers && \
+    conda run -n octave-kernel python -m ipykernel install --user --name octave-kernel --display-name "Octave" && \
+
+    conda create -n python-kernel-3.12 --yes python=3.12 ipykernel && \
+    conda run -n python-kernel-3.12 pip install bioblend galaxy-ie-helpers && \
+    conda run -n python-kernel-3.12 python -m ipykernel install --user --name python-kernel-3.12 --display-name "Python 3.12" && \
+    
+    conda create -n rlang-kernel --yes r-base r-irkernel r-xml rpy2 \
+    	    'r-caret' \
+	    'r-crayon' \
+	    'r-devtools' \
+	    'r-e1071' \
+	    'r-forecast' \
+	    'r-hexbin' \
+	    'r-htmltools' \
+	    'r-htmlwidgets' \
+	    'r-irkernel' \
+	    'r-nycflights13' \
+	    'r-randomforest' \
+	    'r-rcurl' \
+	    'r-rmarkdown' \
+	    'r-rodbc' \
+	    'r-rsqlite' \
+	    'r-shiny' \
+	    'r-tidymodels' \
+	    'r-tidyverse' \
+	    'unixodbc' && \
+    conda run -n rlang-kernel pip install bioblend galaxy-ie-helpers && \
+    conda run -n rlang-kernel R -e 'IRkernel::installspec(user = TRUE)' && \
+
     conda clean --all -y && \
     chmod a+w+r /opt/conda/ -R
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,6 @@ RUN conda install --yes \
     cloudpickle \
     cython \
     dill \
-    # https://github.com/anaconda/nb_conda_kernels
-    nb_conda_kernels \
     jupytext \
     jupyterlab-geojson \
     jupyterlab-katex \
@@ -32,12 +30,13 @@ RUN conda install --yes \
     patsy \
     pip \
     statsmodels && \
-    ##
-    ## Now create separate environments, that are managed by nb_conda_kernels
-    ##
-    conda create -n python-kernel-3.12 --yes python=3.12 ipykernel bioblend galaxy-ie-helpers && \
-    conda run -n python-kernel-3.12 python -m ipykernel install --user --name python-kernel-3.12 --display-name "Python 3.12" && \
-    conda create -n rlang-kernel --yes r-base r-irkernel r-xml rpy2 bioblend galaxy-ie-helpers \
+    conda create -n bash-kernel --yes bash_kernel=0.10.0 bioblend galaxy-ie-helpers && \
+    conda run -n bash-kernel python -m bash_kernel.install --user && \
+    conda create -n ansible-kernel --yes ansible-kernel=1.0.0 jupyter_client bioblend galaxy-ie-helpers && \
+    conda run -n ansible-kernel python -m ansible_kernel.install && \
+    conda create -n octave-kernel --yes python=3.8 octave_kernel=0.36.0 bioblend galaxy-ie-helpers && \
+    conda run -n octave-kernel python -m octave_kernel install --user && \
+    conda create -n rlang-kernel --yes r-base r-irkernel=1.3.2 r-xml rpy2 bioblend galaxy-ie-helpers \
     	    'r-caret' \
 	    'r-crayon' \
 	    'r-devtools' \
@@ -57,14 +56,7 @@ RUN conda install --yes \
 	    'r-tidymodels' \
 	    'r-tidyverse' \
 	    'unixodbc' && \
-    conda run -n rlang-kernel R -e 'IRkernel::installspec(user = TRUE)' && \
-    conda create -n bash-kernel --yes bash_kernel bioblend galaxy-ie-helpers && \
-    conda run -n bash-kernel python -m bash_kernel.install --user && \
-    conda create -n octave-kernel python=3.8 --yes && \
-    conda run -n octave-kernel pip install octave_kernel bioblend galaxy-ie-helpers && \
-    conda run -n octave-kernel python -m octave_kernel install --user&& \
-    conda create -n ansible-kernel --yes ansible-kernel jupyter_client bioblend galaxy-ie-helpers && \
-    conda run -n ansible-kernel python -m ansible_kernel.install && \
+    conda run -n rlang-kernel R -e "IRkernel::installspec(user = TRUE, name = 'rlang-kernel', displayname = 'R')" && \
     conda clean --all -y && \
     chmod a+w+r /opt/conda/ -R
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,7 @@ RUN conda install --yes \
 
 RUN echo 'Sys.setenv(CONDA_PREFIX = "/opt/conda/envs/rlang-kernel")' >> /home/$NB_USER/.Rprofile && \
     echo 'Sys.setenv(PATH = paste("/opt/conda/envs/rlang-kernel/bin", Sys.getenv("PATH"), sep=":"))' >> /home/$NB_USER/.Rprofile && \
+    echo 'Sys.setenv(PROJ_LIB = "/opt/conda/envs/rlang-kernel/share/proj")' >> /home/$NB_USER/.Rprofile && \
     chown $NB_USER /home/$NB_USER/.Rprofile
 
 ADD ./startup.sh /startup.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ RUN conda install --yes \
     conda run -n rlang-kernel R -e 'IRkernel::installspec(user = TRUE)' && \
     conda create -n bash-kernel --yes bash_kernel bioblend galaxy-ie-helpers && \
     conda run -n bash-kernel python -m bash_kernel.install --user && \
-    UN conda create -n octave-kernel python=3.8 --yes && \
+    conda create -n octave-kernel python=3.8 --yes && \
     conda run -n octave-kernel pip install octave_kernel bioblend galaxy-ie-helpers && \
     conda run -n octave-kernel python -m octave_kernel install --user&& \
     conda create -n ansible-kernel --yes ansible-kernel jupyter_client bioblend galaxy-ie-helpers && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
- # Jupyter container used for Galaxy IPython (+other kernels) Integration
+# Jupyter container used for Galaxy IPython (+other kernels) Integration
 
 # We want to support Python, R, Julia, Bash and to a lesser degree ansible, octave
 # https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # Jupyter container used for Galaxy IPython (+other kernels) Integration
 
-# Jupyter container used for Galaxy IPython (+other kernels) Integration
-
 # We want to support Python, R, Julia, Bash and to a lesser degree ansible, octave
 # https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html
 # Accoring to the link above we should take scipy-notebook and add additional kernels.
@@ -134,4 +132,4 @@ RUN mkdir -p /import/jupyter/outputs/ && \
 WORKDIR /import
 
 # Start Jupyter Notebook
-CMD /startup.sh 
+CMD /startup.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,7 +68,9 @@ RUN conda install --yes \
     conda clean --all -y && \
     chmod a+w+r /opt/conda/ -R
 
-    
+RUN echo 'Sys.setenv(CONDA_PREFIX = "/opt/conda/envs/rlang-kernel")' >> /home/$NB_USER/.Rprofile && \
+    echo 'Sys.setenv(PATH = paste("/opt/conda/envs/rlang-kernel/bin", Sys.getenv("PATH"), sep=":"))' >> /home/$NB_USER/.Rprofile && \
+    chown $NB_USER /home/$NB_USER/.Rprofile
 
 ADD ./startup.sh /startup.sh
 #ADD ./monitor_traffic.sh /monitor_traffic.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# Jupyter container used for Galaxy IPython (+other kernels) Integration
+ # Jupyter container used for Galaxy IPython (+other kernels) Integration
 
 # We want to support Python, R, Julia, Bash and to a lesser degree ansible, octave
 # https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html
@@ -17,7 +17,7 @@ RUN conda config --add channels bioconda && \
     conda --version
 
 # Install python and jupyter packages
-RUN conda install --yes \ 
+RUN conda install --yes \
     bioblend galaxy-ie-helpers \
     biopython \
     cloudpickle \
@@ -31,15 +31,13 @@ RUN conda install --yes \
     jupyterlab-fasta \
     patsy \
     pip \
-    statsmodels 
+    statsmodels && \
     ##
     ## Now create separate environments, that are managed by nb_conda_kernels
     ##
- 
-RUN conda create -n python-kernel-3.12 --yes python=3.12 ipykernel bioblend galaxy-ie-helpers && \
-    conda run -n python-kernel-3.12 python -m ipykernel install --user --name python-kernel-3.12 --display-name "Python 3.12" 
-    
-RUN conda create -n rlang-kernel --yes r-base r-irkernel r-xml rpy2 bioblend galaxy-ie-helpers \
+    conda create -n python-kernel-3.12 --yes python=3.12 ipykernel bioblend galaxy-ie-helpers && \
+    conda run -n python-kernel-3.12 python -m ipykernel install --user --name python-kernel-3.12 --display-name "Python 3.12" && \
+    conda create -n rlang-kernel --yes r-base r-irkernel r-xml rpy2 bioblend galaxy-ie-helpers \
     	    'r-caret' \
 	    'r-crayon' \
 	    'r-devtools' \
@@ -59,20 +57,18 @@ RUN conda create -n rlang-kernel --yes r-base r-irkernel r-xml rpy2 bioblend gal
 	    'r-tidymodels' \
 	    'r-tidyverse' \
 	    'unixodbc' && \
-    conda run -n rlang-kernel R -e 'IRkernel::installspec(user = TRUE)' 
-
-RUN conda create -n bash-kernel --yes bash_kernel bioblend galaxy-ie-helpers && \
-    conda run -n bash-kernel python -m bash_kernel.install --user 
-
-RUN conda create -n octave-kernel python=3.8 --yes && \
+    conda run -n rlang-kernel R -e 'IRkernel::installspec(user = TRUE)' && \
+    conda create -n bash-kernel --yes bash_kernel bioblend galaxy-ie-helpers && \
+    conda run -n bash-kernel python -m bash_kernel.install --user && \
+    UN conda create -n octave-kernel python=3.8 --yes && \
     conda run -n octave-kernel pip install octave_kernel bioblend galaxy-ie-helpers && \
-    conda run -n octave-kernel python -m octave_kernel install --user
-
-RUN conda create -n ansible-kernel --yes ansible-kernel jupyter_client bioblend galaxy-ie-helpers && \
-    conda run -n ansible-kernel python -m ansible_kernel.install
-
-RUN conda clean --all -y && \
+    conda run -n octave-kernel python -m octave_kernel install --user&& \
+    conda create -n ansible-kernel --yes ansible-kernel jupyter_client bioblend galaxy-ie-helpers && \
+    conda run -n ansible-kernel python -m ansible_kernel.install && \
+    conda clean --all -y && \
     chmod a+w+r /opt/conda/ -R
+
+    
 
 ADD ./startup.sh /startup.sh
 #ADD ./monitor_traffic.sh /monitor_traffic.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Jupyter container used for Galaxy IPython (+other kernels) Integration
 
+# Jupyter container used for Galaxy IPython (+other kernels) Integration
+
 # We want to support Python, R, Julia, Bash and to a lesser degree ansible, octave
 # https://jupyter-docker-stacks.readthedocs.io/en/latest/using/selecting.html
 # Accoring to the link above we should take scipy-notebook and add additional kernels.
@@ -31,27 +33,15 @@ RUN conda install --yes \
     jupyterlab-fasta \
     patsy \
     pip \
-    statsmodels && \
+    statsmodels 
     ##
     ## Now create separate environments, that are managed by nb_conda_kernels
     ##
-    conda create -n ansible-kernel --yes && \
-    conda run -n ansible-kernel pip install ipykernel bioblend galaxy-ie-helpers && \
-    conda run -n ansible-kernel python -m ipykernel install --user --name ansible-kernel --display-name "Ansible Kernel" && \
-
-    conda create -n bash-kernel --yes && \
-    conda run -n bash-kernel pip install bash_kernel bioblend galaxy-ie-helpers && \
-    conda run -n bash-kernel python -m ipykernel install --user --name bash-kernel --display-name "bash" && \
-
-    conda create -n octave-kernel --yes && \
-    conda run -n octave-kernel pip install octave-kernel bioblend galaxy-ie-helpers && \
-    conda run -n octave-kernel python -m ipykernel install --user --name octave-kernel --display-name "Octave" && \
-
-    conda create -n python-kernel-3.12 --yes python=3.12 ipykernel && \
-    conda run -n python-kernel-3.12 pip install bioblend galaxy-ie-helpers && \
-    conda run -n python-kernel-3.12 python -m ipykernel install --user --name python-kernel-3.12 --display-name "Python 3.12" && \
+ 
+RUN conda create -n python-kernel-3.12 --yes python=3.12 ipykernel bioblend galaxy-ie-helpers && \
+    conda run -n python-kernel-3.12 python -m ipykernel install --user --name python-kernel-3.12 --display-name "Python 3.12" 
     
-    conda create -n rlang-kernel --yes r-base r-irkernel r-xml rpy2 \
+RUN conda create -n rlang-kernel --yes r-base r-irkernel r-xml rpy2 bioblend galaxy-ie-helpers \
     	    'r-caret' \
 	    'r-crayon' \
 	    'r-devtools' \
@@ -71,11 +61,17 @@ RUN conda install --yes \
 	    'r-tidymodels' \
 	    'r-tidyverse' \
 	    'unixodbc' && \
-    conda run -n rlang-kernel pip install bioblend galaxy-ie-helpers && \
-    conda run -n rlang-kernel R -e 'IRkernel::installspec(user = TRUE)' && \
+    conda run -n rlang-kernel R -e 'IRkernel::installspec(user = TRUE)' 
 
-    conda clean --all -y && \
-    chmod a+w+r /opt/conda/ -R
+RUN conda create -n bash-kernel --yes bash_kernel bioblend galaxy-ie-helpers && \
+    conda run -n bash-kernel python -m bash_kernel.install --user 
+
+RUN conda create -n octave-kernel python=3.8 --yes && \
+    conda run -n octave-kernel pip install octave_kernel bioblend galaxy-ie-helpers && \
+    conda run -n octave-kernel python -m octave_kernel install --user
+
+RUN conda create -n ansible-kernel --yes ansible-kernel jupyter_client bioblend galaxy-ie-helpers && \
+    conda run -n ansible-kernel python -m ansible_kernel.install
 
 ADD ./startup.sh /startup.sh
 #ADD ./monitor_traffic.sh /monitor_traffic.sh
@@ -135,4 +131,4 @@ RUN mkdir -p /import/jupyter/outputs/ && \
 WORKDIR /import
 
 # Start Jupyter Notebook
-CMD /startup.sh
+CMD /startup.sh 


### PR DESCRIPTION
Hello,
I am a master's student doing my internship with @yvanlebras . I need to create a workflow on Galaxy and noticed an issue with the latest Jupyter tool in Galaxy. Since it cannot be used in batch mode, I looked for a simple way to fix it. From what I implemented, it seems to work. I used pip install inside Conda and, most importantly, ipykernel, which allows Jupyter to correctly recognize the kernel paths and manually name them.
